### PR TITLE
Improved comment consistency

### DIFF
--- a/Source/S05_TestingGrounds.Target.cs
+++ b/Source/S05_TestingGrounds.Target.cs
@@ -10,10 +10,9 @@ public class S05_TestingGroundsTarget : TargetRules
 		Type = TargetType.Game;
 	}
 
-	//
-	// TargetRules interface.
-	//
-
+	/**
+	* TargetRules interface.
+	*/
 	public override void SetupBinaries(
 		TargetInfo Target,
 		ref List<UEBuildBinaryConfiguration> OutBuildBinaryConfigurations,

--- a/Source/S05_TestingGrounds/Player/FirstPersonCharacter.cpp
+++ b/Source/S05_TestingGrounds/Player/FirstPersonCharacter.cpp
@@ -15,7 +15,7 @@ AFirstPersonCharacter::AFirstPersonCharacter()
 	// Set size for collision capsule
 	GetCapsuleComponent()->InitCapsuleSize(55.f, 96.0f);
 
-	// set our turn rates for input
+	// Set our turn rates for input
 	BaseTurnRate = 45.f;
 	BaseLookUpRate = 45.f;
 
@@ -37,8 +37,9 @@ AFirstPersonCharacter::AFirstPersonCharacter()
 	// Default offset from the character location for projectiles to spawn
 	GunOffset = FVector(100.0f, 30.0f, 10.0f);
 
-	// Note: The ProjectileClass and the skeletal mesh/anim blueprints for Mesh1P are set in the
-	// derived blueprint asset named MyCharacter (to avoid direct content references in C++)
+	/* Note: The ProjectileClass and the skeletal mesh/anim blueprints for Mesh1P are set in the
+	   derived blueprint asset named MyCharacter (to avoid direct content references in C++)
+	*/
 }
 
 void AFirstPersonCharacter::BeginPlay()
@@ -64,19 +65,20 @@ void AFirstPersonCharacter::BeginPlay()
 
 void AFirstPersonCharacter::SetupPlayerInputComponent(class UInputComponent* InputComponent)
 {
-	// set up gameplay key bindings
+	// Set up gameplay key bindings
 	check(InputComponent);
 
 	InputComponent->BindAction("Jump", IE_Pressed, this, &ACharacter::Jump);
 	InputComponent->BindAction("Jump", IE_Released, this, &ACharacter::StopJumping);
 
-	//InputComponent->BindTouch(EInputEvent::IE_Pressed, this, &AFirstPersonCharacter::TouchStarted);
+	// InputComponent->BindTouch(EInputEvent::IE_Pressed, this, &AFirstPersonCharacter::TouchStarted);
 	InputComponent->BindAxis("MoveForward", this, &AFirstPersonCharacter::MoveForward);
 	InputComponent->BindAxis("MoveRight", this, &AFirstPersonCharacter::MoveRight);
 
-	// We have 2 versions of the rotation bindings to handle different kinds of devices differently
-	// "turn" handles devices that provide an absolute delta, such as a mouse.
-	// "turnrate" is for devices that we choose to treat as a rate of change, such as an analog joystick
+	/* We have 2 versions of the rotation bindings to handle different kinds of devices differently
+	  "turn" handles devices that provide an absolute delta, such as a mouse.
+	  "turnrate" is for devices that we choose to treat as a rate of change, such as an analog joystick
+	*/
 	InputComponent->BindAxis("Turn", this, &APawn::AddControllerYawInput);
 	InputComponent->BindAxis("TurnRate", this, &AFirstPersonCharacter::TurnAtRate);
 	InputComponent->BindAxis("LookUp", this, &APawn::AddControllerPitchInput);
@@ -149,7 +151,7 @@ void AFirstPersonCharacter::MoveForward(float Value)
 {
 	if (Value != 0.0f)
 	{
-		// add movement in that direction
+		// Add movement in that direction
 		AddMovementInput(GetActorForwardVector(), Value);
 	}
 }
@@ -158,20 +160,20 @@ void AFirstPersonCharacter::MoveRight(float Value)
 {
 	if (Value != 0.0f)
 	{
-		// add movement in that direction
+		// Add movement in that direction
 		AddMovementInput(GetActorRightVector(), Value);
 	}
 }
 
 void AFirstPersonCharacter::TurnAtRate(float Rate)
 {
-	// calculate delta for this frame from the rate information
+	// Calculate delta for this frame from the rate information
 	AddControllerYawInput(Rate * BaseTurnRate * GetWorld()->GetDeltaSeconds());
 }
 
 void AFirstPersonCharacter::LookUpAtRate(float Rate)
 {
-	// calculate delta for this frame from the rate information
+	// Calculate delta for this frame from the rate information
 	AddControllerPitchInput(Rate * BaseLookUpRate * GetWorld()->GetDeltaSeconds());
 }
 

--- a/Source/S05_TestingGrounds/Player/FirstPersonCharacter.h
+++ b/Source/S05_TestingGrounds/Player/FirstPersonCharacter.h
@@ -88,9 +88,9 @@ protected:
 	bool EnableTouchscreenMovement(UInputComponent* InputComponent);
 
 public:
-	/** Returns Mesh1P subobject **/
+	/** Returns Mesh1P subobject */
 	FORCEINLINE class USkeletalMeshComponent* GetMesh1P() const { return Mesh1P; }
-	/** Returns FirstPersonCameraComponent subobject **/
+	/** Returns FirstPersonCameraComponent subobject */
 	FORCEINLINE class UCameraComponent* GetFirstPersonCameraComponent() const { return FirstPersonCameraComponent; }
 
 };

--- a/Source/S05_TestingGrounds/S05_TestingGroundsGameMode.cpp
+++ b/Source/S05_TestingGrounds/S05_TestingGroundsGameMode.cpp
@@ -8,10 +8,10 @@
 AS05_TestingGroundsGameMode::AS05_TestingGroundsGameMode()
 	: Super()
 {
-	// set default pawn class to our Blueprinted character
+	// Set default pawn class to our Blueprinted character
 	static ConstructorHelpers::FClassFinder<APawn> PlayerPawnClassFinder(TEXT("/Game/Dynamic/Player/Behaviour/FirstPersonCharacter"));
 	DefaultPawnClass = PlayerPawnClassFinder.Class;
 
-	// use our custom HUD class
+	// Use our custom HUD class
 	HUDClass = AS05_TestingGroundsHUD::StaticClass();
 }

--- a/Source/S05_TestingGrounds/S05_TestingGroundsHUD.cpp
+++ b/Source/S05_TestingGrounds/S05_TestingGroundsHUD.cpp
@@ -20,14 +20,14 @@ void AS05_TestingGroundsHUD::DrawHUD()
 
 	// Draw very simple crosshair
 
-	// find center of the Canvas
+	// Find center of the Canvas
 	const FVector2D Center(Canvas->ClipX * 0.5f, Canvas->ClipY * 0.5f);
 
-	// offset by half the texture's dimensions so that the center of the texture aligns with the center of the Canvas
+	// Offset by half the texture's dimensions so that the center of the texture aligns with the center of the Canvas
 	const FVector2D CrosshairDrawPosition( (Center.X),
 										   (Center.Y));
 
-	// draw the crosshair
+	// Draw the crosshair
 	FCanvasTileItem TileItem( CrosshairDrawPosition, CrosshairTex->Resource, FLinearColor::White);
 	TileItem.BlendMode = SE_BLEND_Translucent;
 	Canvas->DrawItem( TileItem );

--- a/Source/S05_TestingGrounds/Weapons/BallProjectile.cpp
+++ b/Source/S05_TestingGrounds/Weapons/BallProjectile.cpp
@@ -10,7 +10,7 @@ ABallProjectile::ABallProjectile()
 	CollisionComp = CreateDefaultSubobject<USphereComponent>(TEXT("SphereComp"));
 	CollisionComp->InitSphereRadius(5.0f);
 	CollisionComp->BodyInstance.SetCollisionProfileName("Projectile");
-	CollisionComp->OnComponentHit.AddDynamic(this, &ABallProjectile::OnHit);		// set up a notification for when this component hits something blocking
+	CollisionComp->OnComponentHit.AddDynamic(this, &ABallProjectile::OnHit);		// Set up a notification for when this component hits something blocking
 
 	// Players can't walk on it
 	CollisionComp->SetWalkableSlopeOverride(FWalkableSlopeOverride(WalkableSlope_Unwalkable, 0.f));

--- a/Source/S05_TestingGrounds/Weapons/BallProjectile.h
+++ b/Source/S05_TestingGrounds/Weapons/BallProjectile.h
@@ -19,13 +19,13 @@ class ABallProjectile : public AActor
 public:
 	ABallProjectile();
 
-	/** called when projectile hits something */
+	/** Called when projectile hits something */
 	UFUNCTION()
 	void OnHit(UPrimitiveComponent* HitComp, AActor* OtherActor, UPrimitiveComponent* OtherComp, FVector NormalImpulse, const FHitResult& Hit);
 
-	/** Returns CollisionComp subobject **/
+	/** Returns CollisionComp subobject */
 	FORCEINLINE class USphereComponent* GetCollisionComp() const { return CollisionComp; }
-	/** Returns ProjectileMovement subobject **/
+	/** Returns ProjectileMovement subobject */
 	FORCEINLINE class UProjectileMovementComponent* GetProjectileMovement() const { return ProjectileMovement; }
 };
 

--- a/Source/S05_TestingGrounds/Weapons/Gun.cpp
+++ b/Source/S05_TestingGrounds/Weapons/Gun.cpp
@@ -40,18 +40,19 @@ void AGun::Tick( float DeltaTime )
 void AGun::OnFire()
 {
 	// try and fire a projectile
-	if (ProjectileClass != NULL)
+	if (ProjectileClass == NULL)
 	{
-		const FRotator SpawnRotation = FP_MuzzleLocation->GetComponentRotation();
-		// MuzzleOffset is in camera space, so transform it to world space before offsetting from the character location to find the final muzzle position
-		const FVector SpawnLocation = FP_MuzzleLocation->GetComponentLocation();
+		return;
+	}
+	const FRotator SpawnRotation = FP_MuzzleLocation->GetComponentRotation();
+	// MuzzleOffset is in camera space, so transform it to world space before offsetting from the character location to find the final muzzle position
+	const FVector SpawnLocation = FP_MuzzleLocation->GetComponentLocation();
 
-		UWorld* const World = GetWorld();
-		if (World != NULL)
-		{
-			// spawn the projectile at the muzzle
-			World->SpawnActor<ABallProjectile>(ProjectileClass, SpawnLocation, SpawnRotation);
-		}
+	UWorld* const World = GetWorld();
+	if (World != NULL)
+	{
+		// spawn the projectile at the muzzle
+		World->SpawnActor<ABallProjectile>(ProjectileClass, SpawnLocation, SpawnRotation);
 	}
 
 	// try and play the sound if specified

--- a/Source/S05_TestingGrounds/Weapons/Gun.cpp
+++ b/Source/S05_TestingGrounds/Weapons/Gun.cpp
@@ -39,7 +39,7 @@ void AGun::Tick( float DeltaTime )
 
 void AGun::OnFire()
 {
-	// try and fire a projectile
+	// Try and fire a projectile
 	if (ProjectileClass == NULL)
 	{
 		return;
@@ -51,17 +51,17 @@ void AGun::OnFire()
 	UWorld* const World = GetWorld();
 	if (World != NULL)
 	{
-		// spawn the projectile at the muzzle
+		// Spawn the projectile at the muzzle
 		World->SpawnActor<ABallProjectile>(ProjectileClass, SpawnLocation, SpawnRotation);
 	}
 
-	// try and play the sound if specified
+	// Try and play the sound if specified
 	if (FireSound != NULL)
 	{
 		UGameplayStatics::PlaySoundAtLocation(this, FireSound, GetActorLocation());
 	}
 
-	// try and play a firing animation if specified
+	// Try and play a firing animation if specified
 	if (FireAnimation != NULL)
 	{
 		// Get the animation object for the arms mesh

--- a/Source/S05_TestingGroundsEditor.Target.cs
+++ b/Source/S05_TestingGroundsEditor.Target.cs
@@ -10,10 +10,9 @@ public class S05_TestingGroundsEditorTarget : TargetRules
 		Type = TargetType.Editor;
 	}
 
-	//
-	// TargetRules interface.
-	//
-
+	/**
+	* TargetRules interface.
+	*/
 	public override void SetupBinaries(
 		TargetInfo Target,
 		ref List<UEBuildBinaryConfiguration> OutBuildBinaryConfigurations,


### PR DESCRIPTION
I improved the style consistency of comments within the code so that the file comments are uniform in style (not with a comment starting with lower case in one spot and capital letter everywhere else, removed unnecessary asterisks in comments, created block comments rather than single line comments comprising a block, etc).

Hopefully these changed help. I have deliberately left the 'Allow edits from maintainers' option checked so that you may edit this as you see fit or see any errors within it.

This addresses issue #4 